### PR TITLE
fix(crash): Fixed exception due to adding nil to array

### DIFF
--- a/TimesSquare/TSQCalendarRowCell.m
+++ b/TimesSquare/TSQCalendarRowCell.m
@@ -595,7 +595,7 @@
     if (index < self.notThisMonthButtons.count) {
         [buttons addObject:self.notThisMonthButtons[index]];
     }
-    if (self.indexOfSelectedButton == (NSInteger)index) {
+    if (self.indexOfSelectedButton == (NSInteger)index && self.selectedButton) {
         [buttons addObject:self.selectedButton];
     }
 


### PR DESCRIPTION
On iOS 15, there seems to be an exception introduced when we try to add a nil item to a particular array:
```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[__NSArrayM insertObject:atIndex:]: object cannot be nil'
```

I was able to track this down by downloading this repo and then replacing the carthage-built framework with this project as a subproject dependency--which allowed me to set breakpoints:
<img src="https://user-images.githubusercontent.com/14121087/151088066-31a38fc7-5af0-4318-92c9-e2a617afba0c.png" width=700px />

This happens when we try to layout a view at index 0--because `self.indexOfSelectedButton == 0` by default (0 and nil are equivalent in objc with non-pointer integers). So I just added a guard so that we ensure `self.selectedButton` is not nil before adding it to the array.

